### PR TITLE
chore: header change note for business api test

### DIFF
--- a/sections/oauth/api-test.md
+++ b/sections/oauth/api-test.md
@@ -1,11 +1,11 @@
-# Business API Test
+# Testing Business API
 
-> Before continuing, please ensure that you have already prepared:
+> Before continuing, please ensure that you have:
 >
-> 1. [At least 1 application with an OAuth 2.1 Client](/sections/oauth/client.md)
-> 1. [Understanding and implementing the Authorization Code flow](sections/oauth/authz-token)
+> - [At least 1 application with an OAuth 2.1 Client](/sections/oauth/client.md)
+> - [Understood and implemented the Authorization Code flow](sections/oauth/authz-token)
 
-The Publisher API Specs can usually be found [in our API Catalog](sections/consuming/browsing-apis?id=_1-discover-apis-through-the-api-catalog) (or if not, contact the Publisher directly).
+The Publisher API specifications can usually be found [in our API Catalog](sections/consuming/browsing-apis?id=_1-discover-apis-through-the-api-catalog). If the specifications are not available, contact the API Publisher directly.
 
 The Business API request through APEX requires these additional headers below.
 
@@ -13,3 +13,6 @@ The Business API request through APEX requires these additional headers below.
 | ------------- | --------------------------------------------------------- |
 | Authorization | Authorization Token obtained from Authorization Code flow |
 | x-apex-apikey | API Key of your application obtained from Step 3 above    |
+
+!> Starting from 1 Dec 2023, please ensure that you update your HTTP Request Header to use **x-apex-apikey** instead of **ApiId** name. Please note that from 3 Feb 2024, **ApiId** will no longer be supported as a valid request header.
+


### PR DESCRIPTION
note: _Starting from 1 Dec 2023, please ensure that you update your HTTP Request Header to use x-apex-apikey instead of ApiId name. Please note that from 3 Feb 2024, ApiId will no longer be supported as a valid request header._

and some minor fixes.